### PR TITLE
add browser field for lib/ version too

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "module": "./lib-esm/IOBuffer.js",
   "types": "./lib/IOBuffer.d.ts",
   "browser": {
-    "./lib-esm/utf8.js": "./lib-esm/utf8.browser.js"
+    "./lib-esm/utf8.js": "./lib-esm/utf8.browser.js",
+    "./lib/utf8.js": "./lib/utf8.browser.js"
   },
   "files": [
     "src",


### PR DESCRIPTION
This patch adds the browser version of utf8.browser.js to the browser field. Without this I get:

```
Uncaught TypeError: util_1.TextDecoder is not a constructor
```

when I try to use the module from budo/browserify because the `util` browser module does not yet have `Text{Encode,Decode}` like node's version, although the environment does.