### PR TITLE
feat: decode text

### DIFF
--- a/src/IOBuffer.ts
+++ b/src/IOBuffer.ts
@@ -1,4 +1,4 @@
-import { decode, encode } from './utf8';
+import { decode, encode } from './text';
 
 const defaultByteLength = 1024 * 8;
 
@@ -364,6 +364,15 @@ export class IOBuffer {
    */
   public readUtf8(n = 1): string {
     return decode(this.readBytes(n));
+  }
+
+  /**
+   * Read the next `n` bytes, return a string decoded with `encoding` and move pointer
+   * forward by `n` bytes.
+   * If no encoding is passed, the function is equivalent to @see {@link IOBuffer#readUtf8}
+   */
+  public decodeText(n = 1, encoding = 'utf-8'): string {
+    return decode(this.readBytes(n), encoding);
   }
 
   /**

--- a/src/__tests__/read.ts
+++ b/src/__tests__/read.ts
@@ -114,4 +114,21 @@ describe('read data', () => {
     theBuffer.seek(1);
     expect(theBuffer.readUtf8()).toBe('4');
   });
+
+  it('decodeText', () => {
+    const theBuffer = new IOBuffer(
+      Buffer.from([
+        42, 0x34, 0x32, 0xe2, 0x82, 0xac, 42, 0x72, 0x75, 0x6e, 0x21, 0xcf,
+        0x79, 0x6f, 0x73, 0x65, 0x6d, 0x69, 0x74, 0x65,
+      ]),
+    );
+    expect(theBuffer.readByte()).toBe(42);
+    const strE1 = theBuffer.decodeText(5);
+    expect(strE1).toBe('42€');
+    expect(theBuffer.readByte()).toBe(42);
+    const strE2 = theBuffer.decodeText(4, 'windows-1251');
+    expect(strE2).toBe('run!');
+    expect(theBuffer.decodeText(1, 'windows-1251')).toBe('П');
+    expect(theBuffer.decodeText(8, 'ISO-8859-2')).toBe('yosemite');
+  });
 });

--- a/src/text.browser.ts
+++ b/src/text.browser.ts
@@ -1,9 +1,8 @@
 // eslint-disable-next-line import/no-unassigned-import
 import './text-encoding-polyfill';
 
-const decoder = new TextDecoder('utf-8');
-
-export function decode(bytes: Uint8Array): string {
+export function decode(bytes: Uint8Array, encoding = 'utf8'): string {
+  const decoder = new TextDecoder(encoding);
   return decoder.decode(bytes);
 }
 

--- a/src/text.ts
+++ b/src/text.ts
@@ -1,8 +1,7 @@
 import { TextDecoder, TextEncoder } from 'util';
 
-const decoder = new TextDecoder('utf-8');
-
-export function decode(bytes: Uint8Array): string {
+export function decode(bytes: Uint8Array, encoding = 'utf8'): string {
+  const decoder = new TextDecoder(encoding);
   return decoder.decode(bytes);
 }
 


### PR DESCRIPTION
`IOBuffer.decodeText` method reads n bytes and passes that to the TextDecoder API as `new TextDecoder(encoding).decode(bytes)`

It should be equivalent to `IOBuffer.readUtf8` when no encoding is given (or when `utf-8` is given)
Probably needs adjustments.