### PR TITLE
Idea: read multiple bytes of a kind and return typed array

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,13 +40,13 @@
   "homepage": "https://github.com/image-js/iobuffer#readme",
   "devDependencies": {
     "@types/jest": "^27.0.3",
-    "@types/node": "^17.0.0",
+    "@types/node": "^18.11.9",
     "eslint": "^8.4.1",
     "eslint-config-cheminfo-typescript": "^10.3.0",
     "jest": "^27.4.5",
     "prettier": "^2.5.1",
     "rimraf": "^3.0.2",
     "ts-jest": "^27.1.2",
-    "typescript": "^4.5.4"
+    "typescript": "^4.9.3"
   }
 }

--- a/src/IOBuffer.ts
+++ b/src/IOBuffer.ts
@@ -285,12 +285,9 @@ export class IOBuffer {
    * @param type - number type of elements to read
    */
   public readArray(size: number, type: keyof typeof typedArrays) {
-    if (type === 'uint8') {
-      return this.readBytes(size);
-    }
     const bytes = typedArrays[type].BYTES_PER_ELEMENT * size;
-    //copy part of part of the buffer
     const offset = this.byteOffset + this.offset;
+    //copy part of part of the buffer
     const slice = this.buffer.slice(offset, offset + bytes);
     const returnArray = new typedArrays[type](slice);
     this.offset += bytes;

--- a/src/IOBuffer.ts
+++ b/src/IOBuffer.ts
@@ -11,9 +11,13 @@ const typedArrays = {
   uint16: Uint16Array,
   int32: Int32Array,
   uint32: Uint32Array,
+  uint64: BigUint64Array,
+  int64: BigInt64Array,
   float32: Float32Array,
   float64: Float64Array,
 };
+
+type TypedArrays = typeof typedArrays;
 
 interface IOBufferOptions {
   /**
@@ -272,26 +276,25 @@ export class IOBuffer {
    * Read `n` bytes and move pointer forward by `n` bytes.
    */
   public readBytes(n = 1): Uint8Array {
-    const bytes = new Uint8Array(n);
-    for (let i = 0; i < n; i++) {
-      bytes[i] = this.readByte();
-    }
-    return bytes;
+    return this.readArray(n, 'uint8');
   }
 
   /**
-   * Makes typed array after reading bytes
+   * Creates an array of corresponding to the type `type` and size `size`.
+   * For example type `uint8` will create a `Uint8Array`.
    * @param size - size of the resulting array
    * @param type - number type of elements to read
    */
-  public readArray(size: number, type: keyof typeof typedArrays) {
+  public readArray<T extends keyof typeof typedArrays>(
+    size: number,
+    type: T,
+  ): InstanceType<TypedArrays[T]> {
     const bytes = typedArrays[type].BYTES_PER_ELEMENT * size;
     const offset = this.byteOffset + this.offset;
-    //copy part of part of the buffer
     const slice = this.buffer.slice(offset, offset + bytes);
     const returnArray = new typedArrays[type](slice);
     this.offset += bytes;
-    return returnArray;
+    return returnArray as InstanceType<TypedArrays[T]>;
   }
   /**
    * Read a 16-bit signed integer and move pointer forward by 2 bytes.

--- a/src/IOBuffer.ts
+++ b/src/IOBuffer.ts
@@ -285,14 +285,15 @@ export class IOBuffer {
    * @param type - number type of elements to read
    */
   public readArray(size: number, type: keyof typeof typedArrays) {
-    const bytes = typedArrays[type].BYTES_PER_ELEMENT * size;
-    const bytesCopy = new Uint8Array(bytes);
     if (type === 'uint8') {
-      return this.readBytes(bytes);
+      return this.readBytes(size);
     }
-    //offset needs to be 0 for the new data view (or multiple of 4)
-    bytesCopy.set(this.readBytes(bytes));
-    const returnArray = new typedArrays[type](bytesCopy.buffer);
+    const bytes = typedArrays[type].BYTES_PER_ELEMENT * size;
+    //copy part of part of the buffer
+    const offset = this.byteOffset + this.offset;
+    const slice = this.buffer.slice(offset, offset + bytes);
+    const returnArray = new typedArrays[type](slice);
+    this.offset += bytes;
     return returnArray;
   }
   /**

--- a/src/__tests__/read.ts
+++ b/src/__tests__/read.ts
@@ -133,21 +133,15 @@ describe('read data', () => {
   });
   it('readArray', () => {
     const theBuffer = new IOBuffer(
-      Buffer.from([
-        42, 0x34, 0x32, 0xe2, 0x82, 0xac, 42, 0x72, 0x75, 0x6e, 0x21, 0xcf,
-        0x79, 0x6f, 0x73, 0x65, 0x6d, 0x69, 0x74, 0x65,
-      ]),
+      Buffer.from([42, 34, 32, 82, 42, 72, 75, 21, 79, 73, 65, 69, 74, 65]),
     );
     const u8Array = theBuffer.readArray(5, 'uint8');
     expect(theBuffer.offset).toBe(5);
-    expect(u8Array).toStrictEqual(new Uint8Array([42, 52, 50, 226, 130]));
+    expect(u8Array).toStrictEqual(new Uint8Array([42, 34, 32, 82, 42]));
     const u32Array = theBuffer.readArray(1, 'uint32');
     expect(theBuffer.offset).toBe(9);
     expect(u32Array).toStrictEqual(
-      new Uint32Array(new Uint8Array([0xac, 42, 0x72, 0x75]).buffer),
-    );
-    expect(u32Array[0]).toBe(
-      0x75 * 256 * 256 * 256 + 0x72 * 256 * 256 + 42 * 256 + 0xac,
+      new Uint32Array(new Uint8Array([72, 75, 21, 79]).buffer),
     );
   });
 });

--- a/src/__tests__/read.ts
+++ b/src/__tests__/read.ts
@@ -131,4 +131,16 @@ describe('read data', () => {
     expect(theBuffer.decodeText(1, 'windows-1251')).toBe('П');
     expect(theBuffer.decodeText(8, 'ISO-8859-2')).toBe('yosemite');
   });
+  it('arrayOf', () => {
+    const theBuffer = new IOBuffer(
+      Buffer.from([
+        42, 0x34, 0x32, 0xe2, 0x82, 0xac, 42, 0x72, 0x75, 0x6e, 0x21, 0xcf,
+        0x79, 0x6f, 0x73, 0x65, 0x6d, 0x69, 0x74, 0x65,
+      ]),
+    );
+    theBuffer.arrayOf(5, 'uint8');
+    expect(theBuffer.offset).toBe(5);
+    theBuffer.arrayOf(1, 'uint32');
+    expect(theBuffer.offset).toBe(9);
+  });
 });

--- a/src/__tests__/read.ts
+++ b/src/__tests__/read.ts
@@ -131,16 +131,23 @@ describe('read data', () => {
     expect(theBuffer.decodeText(1, 'windows-1251')).toBe('П');
     expect(theBuffer.decodeText(8, 'ISO-8859-2')).toBe('yosemite');
   });
-  it('arrayOf', () => {
+  it('readArray', () => {
     const theBuffer = new IOBuffer(
       Buffer.from([
         42, 0x34, 0x32, 0xe2, 0x82, 0xac, 42, 0x72, 0x75, 0x6e, 0x21, 0xcf,
         0x79, 0x6f, 0x73, 0x65, 0x6d, 0x69, 0x74, 0x65,
       ]),
     );
-    theBuffer.arrayOf(5, 'uint8');
+    const u8Array = theBuffer.readArray(5, 'uint8');
     expect(theBuffer.offset).toBe(5);
-    theBuffer.arrayOf(1, 'uint32');
+    expect(u8Array).toStrictEqual(new Uint8Array([42, 52, 50, 226, 130]));
+    const u32Array = theBuffer.readArray(1, 'uint32');
     expect(theBuffer.offset).toBe(9);
+    expect(u32Array).toStrictEqual(
+      new Uint32Array(new Uint8Array([0xac, 42, 0x72, 0x75]).buffer),
+    );
+    expect(u32Array[0]).toBe(
+      0x75 * 256 * 256 * 256 + 0x72 * 256 * 256 + 42 * 256 + 0xac,
+    );
   });
 });

--- a/src/__tests__/read.ts
+++ b/src/__tests__/read.ts
@@ -131,6 +131,7 @@ describe('read data', () => {
     expect(theBuffer.decodeText(1, 'windows-1251')).toBe('П');
     expect(theBuffer.decodeText(8, 'ISO-8859-2')).toBe('yosemite');
   });
+
   it('readArray', () => {
     const theBuffer = new IOBuffer(
       Buffer.from([42, 34, 32, 82, 42, 72, 75, 21, 79, 73, 65, 69, 74, 65]),


### PR DESCRIPTION
**What is solves**

A user could type `buffer.arrayOf("int16", 8)` and get a typed array of `int16`s, moving also the pointer forward.

This will simplify some lines like `new TypedArray(size)` and looping over it explicitly in the code.

--------------

It may not be useful enough. If it is I will improve it.