### PR TITLE
Do not copy data in readArray when possible

### DIFF
--- a/src/IOBuffer.ts
+++ b/src/IOBuffer.ts
@@ -297,7 +297,6 @@ export class IOBuffer {
   ): InstanceType<TypedArrays[T]> {
     const bytes = typedArrays[type].BYTES_PER_ELEMENT * size;
     const offset = this.byteOffset + this.offset;
-    const slice = this.buffer.slice(offset, offset + bytes);
     if (
       this.littleEndian === hostBigEndian &&
       type !== 'uint8' &&
@@ -310,7 +309,18 @@ export class IOBuffer {
       returnArray.reverse();
       return returnArray as InstanceType<TypedArrays[T]>;
     }
-    const returnArray = new typedArrays[type](slice);
+
+    let returnArray = null;
+    if (
+      typedArrays[type].BYTES_PER_ELEMENT === 1 ||
+      offset % typedArrays[type].BYTES_PER_ELEMENT === 0
+    ) {
+      returnArray = new typedArrays[type](this.buffer, offset, size);
+    } else {
+      const slice = this.buffer.slice(offset, offset + bytes);
+      returnArray = new typedArrays[type](slice);
+    }
+
     this.offset += bytes;
     return returnArray as InstanceType<TypedArrays[T]>;
   }

--- a/src/__tests__/readArray.ts
+++ b/src/__tests__/readArray.ts
@@ -151,4 +151,21 @@ describe('readArray', () => {
     expect(resBE[0]).toBe(firstNumber);
     expect(resBE[1]).toBe(secondNumber);
   });
+  it('offset not multiple', () => {
+    const buffer = new IOBuffer(new Uint8Array([1, 2, 3, 4, 5, 6]));
+
+    //offset is multiple
+    buffer.offset = 2;
+    const res = buffer.readArray(2, 'int16');
+    expect(buffer.offset).toBe(6);
+    expect(res[0]).toBe(3 + (4 << 8));
+    expect(res[1]).toBe(5 + (6 << 8));
+
+    //offset is not multiple and make sure that we don't have such error `start offset of Int16Array should be a multiple of 2`
+    buffer.offset = 1;
+    const resNotMultipleOffset = buffer.readArray(2, 'int16');
+    expect(buffer.offset).toBe(5);
+    expect(resNotMultipleOffset[0]).toBe(2 + (3 << 8));
+    expect(resNotMultipleOffset[1]).toBe(4 + (5 << 8));
+  });
 });


### PR DESCRIPTION
To avoid copying data (using slice), the TypedArray can be created with the arrayBuffer. However it handles only when start offset is a multiple of its type bytes occupancy (otherwise it will trigger similar error : `start offset of Int16Array should be a multiple of 2`). I'll use it when it is possible.

However, since the data is not longer copied, this could have bad consequences if a depend library modified the read data.

I also move line `const slice = this.buffer.slice(offset, offset + bytes);` as in some case the variable is not used (when entering right after in the if condition).